### PR TITLE
Remove: unused go dep package

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -79,9 +79,6 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 755 "$GOPATH/bin"
 
-COPY go-dep /go-dep/
-RUN cd /go-dep/ && sha256sum dep-linux-amd64.sha256 && chmod +x dep-linux-amd64 && mv dep-linux-amd64 "$GOPATH/bin/dep" && cd -
-
 #install CF CLI
 RUN wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add -
 RUN echo "deb http://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list

--- a/pipelines/docker.yml
+++ b/pipelines/docker.yml
@@ -62,12 +62,6 @@ resources:
 
 # dependency resources
 
-- name: go-dep
-  type: github-release
-  source:
-    access_token: ((github_public_repo_token))
-    owner: golang
-    repository: dep
 jobs:
 - name: build-and-push-pivnet
   plan:
@@ -83,23 +77,6 @@ jobs:
   plan:
   - get: ci-dockerfile
     trigger: true
-  - get: go-dep
-  - task: copy-dep
-    config:
-      inputs:
-        - name: go-dep
-        - name: ci-dockerfile
-      outputs:
-        - name: docker-build-dir
-      platform: linux
-      image_resource: {type: docker-image, source: {repository: pivotalgreenhouse/ci}}
-      run:
-        path: cp
-        args:
-          - -R
-          - go-dep
-          - ci-dockerfile/docker
-          - docker-build-dir
   - put: ci-image
     params:
       build: docker-build-dir


### PR DESCRIPTION
dep is the deprecated package manager for golang.

We don't actually use dep anywhere in our code as far as I can see, and
even if we do we should move that code toward using golang modules.