### PR TITLE
Also delete `system` blobs from the unpublishedpremiumstore.

### DIFF
--- a/tasks/clean-up-pre-release-blobstore/run
+++ b/tasks/clean-up-pre-release-blobstore/run
@@ -1,11 +1,20 @@
 #!/bin/bash
 
-echo "If you see the following error don't worry everything is working, the images got deleted, but some did not need to be deleted:"
+echo "If you see the following error don't worry everything is working, the images got deleted, but some did not need to be deleted (they are less than 90 days old):"
 echo "'X of Y blobs not deleted due to Failed Precondition'"
 
+echo "Deleting blobs from `images`"
 az storage blob delete-batch \
   --auth-mode key \
   --account-key $AZURE_STORAGE_ACCESS_KEY \
   --account-name $AZURE_STORAGE_ACCOUNT \
   --source=images --pattern="*.vhd" \
+  --if-unmodified-since=$(date -d "90 days ago" '+%Y-%m-%dT%H:%MZ')
+
+echo "Deleting blobs from `system`"
+az storage blob delete-batch \
+  --auth-mode key \
+  --account-key $AZURE_STORAGE_ACCESS_KEY \
+  --account-name $AZURE_STORAGE_ACCOUNT \
+  --source=system --pattern="*.vhd" \
   --if-unmodified-since=$(date -d "90 days ago" '+%Y-%m-%dT%H:%MZ')


### PR DESCRIPTION
- We were only deleting blobs from the `images` directory, which was
  pretty good, but the `system` directory wound up filling up our quota.
  This change deletes from both directories.