### PR TITLE
Bump ruby in Dockerfile.ci to 2.7.6

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -1,5 +1,5 @@
 #docker pull pivotalgreenhouse/ci
-FROM ruby:2.5.1
+FROM ruby:2.7.6
 
 ARG VCENTER_CA_CERT
 


### PR DESCRIPTION
[#182942799] Ops Manager create export does not clean up tmp files