### PR TITLE
Retrieve latest binaries for some stemcell dependencies

### DIFF
--- a/pipelines/base.yml
+++ b/pipelines/base.yml
@@ -321,6 +321,26 @@ resources:
     uri: git@github.com:pivotal-cf-experimental/Bosh-Windows-Locks
 
 # s3 buckets
+- name: blobstore-s3-cli
+  type: s3
+  source:
+    bucket: s3cli-artifacts
+    regexp: s3cli-(.*)-windows-amd64.exe
+
+- name: blobstore-dav-cli
+  type: s3
+  source:
+    bucket: davcli
+    regexp: davcli-(.*)-windows-amd64.exe
+
+- name: windows-bsdtar
+  type: s3
+  source:
+    bucket: bosh-windows-dependencies
+    regexp: tar-(.*).exe
+    access_key_id: ((bosh_windows_ci_aws_access_key.username))
+    secret_access_key: ((bosh_windows_ci_aws_access_key.password))
+
 - name: stembuild-linux-stemcell
   type: s3
   source:
@@ -691,6 +711,9 @@ jobs:
       - put: nimbus-ips
         params: { acquire: true }
       - get: govc-image
+      - get: blobstore-dav-cli
+      - get: blobstore-s3-cli
+      - get: windows-bsdtar
   - put: version
     resource: stembuild-windows-build-number
     params:
@@ -1255,6 +1278,9 @@ jobs:
         passed: [build]
       - get: bosh-psmodules-repo
         passed: [build]
+      - get: blobstore-dav-cli
+      - get: blobstore-s3-cli
+      - get: windows-bsdtar
   - put: version
     resource: aws-build-number
     params:
@@ -1594,6 +1620,9 @@ jobs:
         passed: [build]
       - get: bosh-psmodules-repo
         passed: [build]
+      - get: blobstore-dav-cli
+      - get: blobstore-s3-cli
+      - get: windows-bsdtar
   - put: version
     resource: azure-build-number
     params:
@@ -1777,6 +1806,9 @@ jobs:
         passed: [build]
       - get: bosh-psmodules-repo
         passed: [build]
+      - get: blobstore-dav-cli
+      - get: blobstore-s3-cli
+      - get: windows-bsdtar
   - put: version
     resource: gcp-build-number
     params:
@@ -2000,6 +2032,9 @@ jobs:
         passed: [promote]
       - get: bosh-psmodules-repo
         passed: [promote]
+      - get: blobstore-dav-cli
+      - get: blobstore-s3-cli
+      - get: windows-bsdtar
   - get: pivnet-public-stemcells
     attempts: 5
   - task: copy-public-stemcells

--- a/tasks/build-agent-zip/task.yml
+++ b/tasks/build-agent-zip/task.yml
@@ -5,6 +5,10 @@ inputs:
 - name: stemcell-builder
 - name: bosh-agent-release
 - name: ci
+- name: blobstore-dav-cli
+- name: blobstore-s3-cli
+- name: windows-bsdtar
+
 outputs:
 - name: bosh-agent
 run:

--- a/tasks/copy-aws-stemcell/task.yml
+++ b/tasks/copy-aws-stemcell/task.yml
@@ -11,6 +11,10 @@ inputs:
   - name: default-stemcell
   - name: bosh-agent-release
   - name: bosh-psmodules-repo
+  - name: blobstore-dav-cli
+  - name: blobstore-s3-cli
+  - name: windows-bsdtar
+
 
 outputs:
   - name: copied-regional-stemcells

--- a/tasks/create-aws-stemcell/task.yml
+++ b/tasks/create-aws-stemcell/task.yml
@@ -13,6 +13,9 @@ inputs:
   - name: packer-ci-private-key
   - name: bosh-agent-release
   - name: bosh-psmodules-repo
+  - name: blobstore-dav-cli
+  - name: blobstore-s3-cli
+  - name: windows-bsdtar
 
 outputs:
   - name: bosh-windows-stemcell

--- a/tasks/create-azure-stemcell/task.yml
+++ b/tasks/create-azure-stemcell/task.yml
@@ -11,6 +11,10 @@ inputs:
   - name: sshd
   - name: bosh-agent-release
   - name: bosh-psmodules-repo
+  - name: blobstore-dav-cli
+  - name: blobstore-s3-cli
+  - name: windows-bsdtar
+
 
 outputs:
   - name: bosh-windows-stemcell

--- a/tasks/create-gcp-stemcell/task.yml
+++ b/tasks/create-gcp-stemcell/task.yml
@@ -12,6 +12,9 @@ inputs:
   - name: sshd
   - name: bosh-agent-release
   - name: bosh-psmodules-repo
+  - name: blobstore-dav-cli
+  - name: blobstore-s3-cli
+  - name: windows-bsdtar
 
 outputs:
   - name: bosh-windows-stemcell


### PR DESCRIPTION
    - Get latest s3 and dav clis.
    - Get latest windows-bsdtar build.
    - Previously we read these files out of the bosh-agent repo (where they
      were seldom updated). This broke when those files were removed to
      accomodate a change introduced by Go 1.19 (see bosh-agent history for
      context).
    - This commit pulls these files directly from the bucket they are placed
      post-build, which ensures we generally have binaries with up-to-date
      dependencies.
    - There may be additional binaries that should be similarly pulled from
      latest vs. copied out of the bosh-agent project.
    - This commit has a similar sibling commit to
      `bosh-windows-stemcell-builder` that uses these newly retrieved
      resources.